### PR TITLE
Remove var_dump when building breadcrumbs

### DIFF
--- a/src/Noherczeg/Breadcrumb/Breadcrumb.php
+++ b/src/Noherczeg/Breadcrumb/Breadcrumb.php
@@ -297,8 +297,6 @@ class Breadcrumb
             // instantiate it
             $builder_instance = new $builder_name($this->segments, $this->base_url);
 
-            var_dump($builder_instance);
-            
             // return with the results :)
             return $builder_instance->build($casing, $last_not_link, $separator, $customizations);
         } else {


### PR DESCRIPTION
It seems a var_dump got left in your commit. Probably a bad idea to leave something like that in master. 

I was going crazy trying to find what part of my code was doing it before I finally realized it wasn't. =)
