### PR TITLE
Pass the Breadcrumb config parameters to the builders.

### DIFF
--- a/src/Noherczeg/Breadcrumb/Breadcrumb.php
+++ b/src/Noherczeg/Breadcrumb/Breadcrumb.php
@@ -357,7 +357,7 @@ class Breadcrumb
             $builder_name = '\\Noherczeg\\Breadcrumb\\Builders\\' . ucfirst($format) . 'Builder';
 
             // instantiate it
-            $builder_instance = new $builder_name($this->segments, $this->base_url);
+            $builder_instance = new $builder_name($this->segments, $this->base_url, $this->config);
 
             // return with the results :)
             return $builder_instance->build($casing, $last_not_link, $separator, $customizations, $different_links);

--- a/src/Noherczeg/Breadcrumb/Builders/BootstrapBuilder.php
+++ b/src/Noherczeg/Breadcrumb/Builders/BootstrapBuilder.php
@@ -2,12 +2,6 @@
 
 class BootstrapBuilder extends Builder
 {
-
-    public function __construct ($segments, $base_url)
-    {
-        parent::__construct($segments, $base_url);
-    }
-
     /**
      * build: The builder method which creates Bootsrap style breadcrumbs
      * 

--- a/src/Noherczeg/Breadcrumb/Builders/Builder.php
+++ b/src/Noherczeg/Breadcrumb/Builders/Builder.php
@@ -9,14 +9,14 @@ abstract class Builder
     protected $base_url = null;
     protected $config = null;
 
-    public function __construct($segments, $base_url)
+    public function __construct($segments, $base_url, $config = array())
     {
         if (!is_array($segments) || empty($segments)) {
             throw new \InvalidArgumentException('A not empty array of Segments is required!');
         } elseif (!is_string($base_url)) {
             throw new \InvalidArgumentException('Base URL should be a string!');
         } else {
-            $this->config = new Config();
+            $this->config = (($config instanceof Config) ? $config : new Config($config));
             $this->segments = $segments;
             $this->base_url = $base_url;
         }

--- a/src/Noherczeg/Breadcrumb/Builders/FoundationBuilder.php
+++ b/src/Noherczeg/Breadcrumb/Builders/FoundationBuilder.php
@@ -2,12 +2,6 @@
 
 class FoundationBuilder extends Builder
 {
-
-    public function __construct ($segments, $base_url)
-    {
-        parent::__construct($segments, $base_url);
-    }
-
     /**
      * build: The builder method which creates Foundation style breadcrumbs
      *

--- a/src/Noherczeg/Breadcrumb/Builders/HtmlBuilder.php
+++ b/src/Noherczeg/Breadcrumb/Builders/HtmlBuilder.php
@@ -2,12 +2,6 @@
 
 class HtmlBuilder extends Builder
 {
-
-    public function __construct ($segments, $base_url)
-    {
-        parent::__construct($segments, $base_url);
-    }
-
     /**
      * build: The builder method which creates HTML style breadcrumbs
      * 

--- a/src/Noherczeg/Breadcrumb/Builders/RichsnippetBuilder.php
+++ b/src/Noherczeg/Breadcrumb/Builders/RichsnippetBuilder.php
@@ -2,12 +2,6 @@
 
 class RichsnippetBuilder extends Builder
 {
-
-    public function __construct ($segments, $base_url)
-    {
-        parent::__construct($segments, $base_url);
-    }
-
     /**
      * build: The builder method which creates rich snippet style breadcrumbs
      * https://support.google.com/webmasters/answer/185417?hl=en


### PR DESCRIPTION
The builders do not inherit the Breadcrumb configuration parameters. If using the given config file, it works. But if you use your own array of parameters, the builders ignore them.
Also, the Builder extended classes do not need their constructors, since they only call the parent constructor.
