### PR TITLE
Fixes #14

### DIFF
--- a/src/Noherczeg/Breadcrumb/Breadcrumb.php
+++ b/src/Noherczeg/Breadcrumb/Breadcrumb.php
@@ -55,7 +55,7 @@ class Breadcrumb
         $this->setConfiguration($config);
 
         // load builders
-        $this->build_formats[] = $this->loadBuilders();
+        $this->build_formats = $this->loadBuilders();
     }
 
     /**

--- a/src/Noherczeg/Breadcrumb/Builders/Builder.php
+++ b/src/Noherczeg/Breadcrumb/Builders/Builder.php
@@ -27,7 +27,7 @@ abstract class Builder
     /** @var boolean */
     private $skipLast;
 
-    public function __construct(array $segments = array(), $base_url = '', array $config = array())
+    public function __construct(array $segments = array(), $base_url = '', $config = array())
     {
         if (!is_string($base_url))
             throw new \InvalidArgumentException('Base URL should be a string!');


### PR DESCRIPTION
removed multi-dimensional build_formats property in Breadcrumb construct
in_array was returning false for the acceptable builds because
the array was multi-dimensional

builder construct argument three was set to array, however in
breadcrumb->build() it was instantiating it with a Config object
causing an argument error; removed array type from this argument
